### PR TITLE
FIX: MissingEntityLink error when supplier not linked to any entity

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,8 +5,10 @@ All notable changes to this project will be documented in this file.
 
 
 ## VERSION 2.2
-
-- NEW : Expedition workflow *05/08/2021* - 2.2.0  
+- FIX: When the third party of the supplier order is not linked to any
+  entity, OFSOM should do nothing but instead the user gets a
+  MissingEntityLink error
+- NEW: Expedition workflow *05/08/2021* - 2.2.0  
   Sur clôture d'une expédition (coté entité fournisseur), permet de faire la reception (coté entité client)
 
 ## VERSION 2.1

--- a/core/modules/modorderfromsupplierordermulticompany.class.php
+++ b/core/modules/modorderfromsupplierordermulticompany.class.php
@@ -61,7 +61,7 @@ class modorderfromsupplierordermulticompany extends DolibarrModules
         // (where XXX is value of numeric property 'numero' of module)
         $this->description = "Description of module orderfromsupplierordermulticompany";
         // Possible values for version are: 'development', 'experimental' or version
-        $this->version = '2.2.0';
+        $this->version = '2.2.1';
         // Key used in llx_const table to save module status enabled/disabled
         // (where MYMODULE is value of property name of module in uppercase)
         $this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/core/triggers/interface_98_modorderfromsupplierordermulticompany_Orderfromsupplierordermulticompanytrigger.class.php
+++ b/core/triggers/interface_98_modorderfromsupplierordermulticompany_Orderfromsupplierordermulticompanytrigger.class.php
@@ -474,7 +474,17 @@ class Interfaceorderfromsupplierordermulticompanytrigger
 
 		$db =& $this->db;
 
-		$res = $db->query("SELECT fk_entity FROM " . MAIN_DB_PREFIX . "thirdparty_entity WHERE entity=" . $conf->entity . " AND fk_soc=" . $object->socid . ' AND fk_entity <> ' . $conf->entity);
+		$res = $db->query("SELECT fk_entity FROM " . MAIN_DB_PREFIX . "thirdparty_entity"
+		                  . " WHERE entity=" . $conf->entity
+		                  . " AND fk_soc=" . $object->socid
+		                  . ' AND fk_entity <> ' . $conf->entity);
+		if (!$res) {
+			// SQL ERROR, should not happen.
+			$this->setError('ErrorSQL');
+		} elseif ($db->num_rows($res) === 0) {
+			// No entity linked to the third party → do nothing
+			return 0;
+		}
 		$obj = $db->fetch_object($res);
 
 		if ($obj->fk_entity > 0) {
@@ -483,7 +493,7 @@ class Interfaceorderfromsupplierordermulticompanytrigger
 			$this->setError($TTELink->error);
 			return $res;
 		} else {
-			$this->error = $langs->trans('MissingEntityLink');
+			$this->setError = $langs->trans('MissingEntityLink');
 			return -1;
 		}
 	}

--- a/core/triggers/interface_98_modorderfromsupplierordermulticompany_Orderfromsupplierordermulticompanytrigger.class.php
+++ b/core/triggers/interface_98_modorderfromsupplierordermulticompany_Orderfromsupplierordermulticompanytrigger.class.php
@@ -493,7 +493,7 @@ class Interfaceorderfromsupplierordermulticompanytrigger
 			$this->setError($TTELink->error);
 			return $res;
 		} else {
-			$this->setError = $langs->trans('MissingEntityLink');
+			$this->setError('MissingEntityLink');
 			return -1;
 		}
 	}


### PR DESCRIPTION
# FIX
Lorsque le trigger OFSOM se déclenche sur une commande fournisseur (passage au statut défini dans la conf du module), si le tiers de la commande (le fournisseur donc) n’est pas lié dans OFSOM à une entité, au lieu de ne rien faire, OFSOM affiche une erreur et interrompt le changement de statut.

Cas classique OFSOM = je suis sur l’entité 1, j’ai lié mon tiers X à l’entité 2 et j’ai configuré OFSOM pour se déclencher à la validation d’une commande fourn ; je valide une commande fourn passée au fournisseur X → comme le lien existe, OFSOM va créer une commande client sur l’entité 2 (le client sera le tiers associé à l’entité 1 sur l’entité 2).

Cas problématique = même setup, sauf que je valide une commande fourn passée au fournisseur Z → ici OFSOM ne devrait rien faire, mais à la place, il affiche un message d’erreur.